### PR TITLE
Adding Ability for TSMarkdownParser to Have Custom Paragraph Formatting

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.h
+++ b/TSMarkdownParser/TSMarkdownParser.h
@@ -31,6 +31,8 @@ typedef void (^TSMarkdownParserFormattingBlock)(NSMutableAttributedString *attri
 
 - (void)addParsingRuleWithRegularExpression:(NSRegularExpression *)regularExpression withBlock:(TSMarkdownParserMatchBlock)block;
 
+- (void)addParagraphParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
+
 - (void)addStrongParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 
 - (void)addEmphasisParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;


### PR DESCRIPTION
This normally wouldn't be necessary, but I would like to give the NSAttributedString that is generated to have the ability to set, for instance, text color of the entire string. It appears that if you parse a string for use in a UITextView and you want the paragraph text to have a different color than, for instance, a bold or header block, there is no way to do this (changing the text color of UITextView overrides any custom colors set in the NSAttributedString).

With this functionality, I can set a paragraph color on all of the text, then override certain blocks with other colors (or formatting).
