### PR TITLE
Attributes for creating the initial attributed string can be passed in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.DS_Store
+*.swp
 
 # CocoaPods
 #

--- a/TSMarkdownParser/TSMarkdownParser.h
+++ b/TSMarkdownParser/TSMarkdownParser.h
@@ -25,9 +25,11 @@ typedef void (^TSMarkdownParserFormattingBlock)(NSMutableAttributedString *attri
 @property (nonatomic, strong) UIColor *linkColor;
 @property (nonatomic, copy) NSNumber *linkUnderlineStyle;
 
-+ (TSMarkdownParser *)standardParser;
++ (instancetype)standardParser;
 
 - (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown;
+
+- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown attributes:(NSDictionary *)attributes;
 
 - (void)addParsingRuleWithRegularExpression:(NSRegularExpression *)regularExpression withBlock:(TSMarkdownParserMatchBlock)block;
 

--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -57,7 +57,7 @@
     return self;
 }
 
-+ (TSMarkdownParser *)standardParser {
++ (instancetype)standardParser {
 
     TSMarkdownParser *defaultParser = [TSMarkdownParser new];
 
@@ -257,12 +257,17 @@ static NSString *const TSMarkdownHeaderRegex    = @"^(#{%i}\\s*)(?!#).*$";
     }
 }
 
-- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown {
-    NSMutableAttributedString *mutableAttributedString = [[NSMutableAttributedString alloc] initWithString:markdown];
+- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown attributes:(NSDictionary *)attributes {
+    NSMutableAttributedString *mutableAttributedString = nil;
+    if (! attributes) {
+        mutableAttributedString = [[NSMutableAttributedString alloc] initWithString:markdown];
+    } else {
+        mutableAttributedString = [[NSMutableAttributedString alloc] initWithString:markdown attributes:attributes];
+    }
     if ( self.paragraphParsingBlock ) {
         self.paragraphParsingBlock(mutableAttributedString);
     }
-
+    
     @synchronized (self) {
         for (TSExpressionBlockPair *expressionBlockPair in self.parsingPairs) {
             NSTextCheckingResult *match;
@@ -272,6 +277,10 @@ static NSString *const TSMarkdownHeaderRegex    = @"^(#{%i}\\s*)(?!#).*$";
         }
     }
     return mutableAttributedString;
+}
+
+- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown {
+    return [self attributedStringFromMarkdown:markdown attributes:nil];
 }
 
 


### PR DESCRIPTION
I've added a `attributedStringFromMarkdown:attributes:` method to pass in the default attributes for the creation of the initial `NSAttributedString` object. Useful to set the things like line-height etc. right upfront