### PR TITLE
adding escapingParsing and unescapingParsing features to defaultParser.

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.h
+++ b/TSMarkdownParser/TSMarkdownParser.h
@@ -37,6 +37,8 @@ typedef void (^TSMarkdownParserFormattingBlock)(NSMutableAttributedString *attri
 
 - (void)addParsingRuleWithRegularExpression:(NSRegularExpression *)regularExpression withBlock:(TSMarkdownParserMatchBlock)block;
 
+- (void)addEscapingParsing;
+
 - (void)addParagraphParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 
 - (void)addStrongParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;

--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -75,8 +75,6 @@
     
     [defaultParser addEscapingParsing];
     
-    [defaultParser addUnescapingParsing];
-    
     [defaultParser addStrongParsingWithFormattingBlock:^(NSMutableAttributedString *attributedString, NSRange range) {
         [attributedString addAttribute:NSFontAttributeName
                                  value:weakParser.strongFont
@@ -186,9 +184,7 @@ static NSString *const TSMarkdownMonospaceRegex        = @"(`+)\\s*([\\s\\S]*?[^
         NSString *escapedString = [NSString stringWithFormat:@"%04x", [matchString characterAtIndex:0]];
         [attributedString replaceCharactersInRange:range withString:escapedString];
     }];
-}
-
-- (void)addUnescapingParsing {
+    
     NSRegularExpression *unescapingParsing = [NSRegularExpression regularExpressionWithPattern:TSMarkdownUnescapingRegex options:NSRegularExpressionDotMatchesLineSeparators error:nil];
     
     [self addFinalParsingRuleWithRegularExpression:unescapingParsing withBlock:^(NSTextCheckingResult *match, NSMutableAttributedString *attributedString) {


### PR DESCRIPTION
This PR is a suggestion at implementing MD escaping. Possible improvements:
* `addUnescapingParsing` might be writable with less lines.
* `addInitialParsingRuleWithRegularExpression:withBlock:` and `addFinalParsingRuleWithRegularExpression:withBlock:` can be made public