### PR TITLE
Fixed that the URL string is not percentage escaped and checked for nil

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -207,7 +207,7 @@ static NSString *const TSMarkdownMonospaceRegex        = @"(`+)\\s*([\\s\\S]*?[^
         NSUInteger linkStartInResult = [attributedString.string rangeOfString:@"(" options:NSBackwardsSearch range:match.range].location;
         NSRange linkRange = NSMakeRange(linkStartInResult, match.range.length+match.range.location-linkStartInResult-1);
         NSString *linkURLString = [attributedString.string substringWithRange:NSMakeRange(linkRange.location+1, linkRange.length-1)];
-        NSURL *url = [NSURL URLWithString:linkURLString];
+        NSURL *url = [NSURL URLWithString:[linkURLString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
         
         NSUInteger linkTextEndLocation = [attributedString.string rangeOfString:@"]" options:0 range:match.range].location;
         NSRange linkTextRange = NSMakeRange(match.range.location, linkTextEndLocation-match.range.location-1);
@@ -215,10 +215,9 @@ static NSString *const TSMarkdownMonospaceRegex        = @"(`+)\\s*([\\s\\S]*?[^
         [attributedString deleteCharactersInRange:NSMakeRange(match.range.location, 1)];
         [attributedString deleteCharactersInRange:NSMakeRange(linkRange.location-2, linkRange.length+2)];
         
-        [attributedString addAttribute:NSLinkAttributeName
-                                 value:url
-                                 range:linkTextRange];
-        
+	if (url) {
+            [attributedString addAttribute:NSLinkAttributeName value:url range:linkTextRange];
+        }
         formattingBlock(attributedString, linkTextRange);
         
     }];


### PR DESCRIPTION
This should fix a crash where link URLs contain a pipe or similar non valid characters.