### PR TITLE
Fixed imports in TSMarkdownParser header and implementation files

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.h
+++ b/TSMarkdownParser/TSMarkdownParser.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Computertalk Sweden. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef void (^TSMarkdownParserMatchBlock)(NSTextCheckingResult *match, NSMutableAttributedString *attributedString);
 typedef void (^TSMarkdownParserFormattingBlock)(NSMutableAttributedString *attributedString, NSRange range);

--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Computertalk Sweden. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "TSMarkdownParser.h"
 
 @interface TSExpressionBlockPair : NSObject


### PR DESCRIPTION
In `TSMarkdownParser` header file, the `UIFont` and `UIColor` properties are defined. That makes it dependent on `UIKit` and the framework should be imported. Otherwise if we import `TSMarkdownParser.h` from file that does not imports `UIKit` we will get "undeclared identifier" errors.
Importing `Foundation` is not required when we import `UIKit` framework.
Importing `UIKit` in `TSMarkdownParser` implementation file is not required when it's imported in the header file.