### PR TITLE
Fixed returning invalid object type

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -320,7 +320,7 @@ static NSString *const TSMarkdownEmRegex        = @"([\\*|_]{1}).+?\\1";
             }
         }
     }
-    return mutableAttributedString;
+    return [mutableAttributedString copy];
 }
 
 @end


### PR DESCRIPTION
Method `attributedStringFromAttributedMarkdownString:` should return `NSAttributedString` object and not the mutable version of it: `NSMutableAttributedString`.