### PR TITLE
TSMarkdownParser 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # * http://www.objc.io/issue-6/travis-ci.html
 # * https://github.com/supermarin/xcpretty#usage
 
+osx_image: xcode7.2
 language: objective-c
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/TSMarkdownParser.xcodeproj/project.pbxproj
+++ b/TSMarkdownParser.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C81B78D11C5483DF00A1DE36 /* TSBaseParser.h in Headers */ = {isa = PBXBuildFile; fileRef = C81B78CF1C5483DF00A1DE36 /* TSBaseParser.h */; };
+		C81B78D21C5483DF00A1DE36 /* TSBaseParser.m in Sources */ = {isa = PBXBuildFile; fileRef = C81B78D01C5483DF00A1DE36 /* TSBaseParser.m */; };
+		C81B78D31C5483DF00A1DE36 /* TSBaseParser.m in Sources */ = {isa = PBXBuildFile; fileRef = C81B78D01C5483DF00A1DE36 /* TSBaseParser.m */; };
+		C81B78D41C5483DF00A1DE36 /* TSBaseParser.m in Sources */ = {isa = PBXBuildFile; fileRef = C81B78D01C5483DF00A1DE36 /* TSBaseParser.m */; };
 		C81B78D51C54B25300A1DE36 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC3C73AAE67D9E3D273712D4 /* UIKit.framework */; };
 		C81B78DE1C54B4B800A1DE36 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C81B78DD1C54B4B800A1DE36 /* main.m */; };
 		C81B78E11C54B4B800A1DE36 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C81B78E01C54B4B800A1DE36 /* AppDelegate.m */; };
@@ -16,6 +20,7 @@
 		C81B78EC1C54B4B800A1DE36 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C81B78EA1C54B4B800A1DE36 /* LaunchScreen.storyboard */; };
 		C81B78F11C54B9E500A1DE36 /* TSMarkdownParser.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3C7B7AEA9B50B9BF782FC5 /* TSMarkdownParser.m */; };
 		C81B78F21C54C05600A1DE36 /* markdown.png in Resources */ = {isa = PBXBuildFile; fileRef = CC3C715C2DB22E3B57578ABE /* markdown.png */; };
+		C8D72E9C1C54DABC00F0E18A /* TSBaseParser.m in Sources */ = {isa = PBXBuildFile; fileRef = C81B78D01C5483DF00A1DE36 /* TSBaseParser.m */; };
 		CC3C74E1CB1870F6AB393F4B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CC3C7F901E1BE8D3F784B45E /* InfoPlist.strings */; };
 		CC3C74E52F377E0874E9D105 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC3C70A3CF901EEE211573EB /* Foundation.framework */; };
 		CC3C763E30B93EB6BA959C47 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC3C7991CED6A71640007C6A /* XCTest.framework */; };
@@ -56,6 +61,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C81B78CF1C5483DF00A1DE36 /* TSBaseParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSBaseParser.h; sourceTree = "<group>"; };
+		C81B78D01C5483DF00A1DE36 /* TSBaseParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSBaseParser.m; sourceTree = "<group>"; };
 		C81B78DA1C54B4B800A1DE36 /* TSMarkdownParser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TSMarkdownParser.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C81B78DD1C54B4B800A1DE36 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		C81B78DF1C54B4B800A1DE36 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -175,6 +182,8 @@
 				CC3C72A1BA2FA83330E38DEB /* Supporting Files */,
 				CC3C79659073897FDCACEC17 /* TSMarkdownParser.h */,
 				CC3C7B7AEA9B50B9BF782FC5 /* TSMarkdownParser.m */,
+				C81B78CF1C5483DF00A1DE36 /* TSBaseParser.h */,
+				C81B78D01C5483DF00A1DE36 /* TSBaseParser.m */,
 			);
 			path = TSMarkdownParser;
 			sourceTree = "<group>";
@@ -245,6 +254,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C81B78D11C5483DF00A1DE36 /* TSBaseParser.h in Headers */,
 				F5A4F45B1B36EF4A00C4F56C /* TSMarkdownParser.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -413,6 +423,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C8D72E9C1C54DABC00F0E18A /* TSBaseParser.m in Sources */,
 				C81B78F11C54B9E500A1DE36 /* TSMarkdownParser.m in Sources */,
 				C81B78E41C54B4B800A1DE36 /* ViewController.m in Sources */,
 				C81B78E11C54B4B800A1DE36 /* AppDelegate.m in Sources */,
@@ -425,6 +436,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CC3C797C733EECEBC569C218 /* TSMarkdownParserTests.m in Sources */,
+				C81B78D31C5483DF00A1DE36 /* TSBaseParser.m in Sources */,
 				CC3C7D016BD3BAD6F43D40B3 /* UIImage+Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -433,6 +445,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C81B78D21C5483DF00A1DE36 /* TSBaseParser.m in Sources */,
 				CC3C78BB152404965D77F4DA /* TSMarkdownParser.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -441,6 +454,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C81B78D41C5483DF00A1DE36 /* TSBaseParser.m in Sources */,
 				F5A4F45C1B36EF4A00C4F56C /* TSMarkdownParser.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TSMarkdownParser/TSBaseParser.h
+++ b/TSMarkdownParser/TSBaseParser.h
@@ -31,13 +31,7 @@ typedef void (^TSMarkdownParserMatchBlock)(NSTextCheckingResult *match, NSMutabl
 /*
  Adds a custom parsing rule to parser. Use `[TSMarkdownParser new]` for an empty parser.
  */
-- (void)addParsingRuleWithRegularExpression:(NSRegularExpression *)regularExpression withBlock:(TSMarkdownParserMatchBlock)block;
-
-/* adds escaping parsing support to parser */
-@property (nonatomic, assign) BOOL escapingSupport;
-
-/* adds links autodetection support to parser */
-@property (nonatomic, assign) BOOL linkDetection;
+- (void)addParsingRuleWithRegularExpression:(NSRegularExpression *)regularExpression block:(TSMarkdownParserMatchBlock)block;
 
 @end
 

--- a/TSMarkdownParser/TSBaseParser.h
+++ b/TSMarkdownParser/TSBaseParser.h
@@ -1,0 +1,44 @@
+//
+//  TSBaseParser.h
+//  TSMarkdownParser
+//
+//  Created by Antoine Cœur on 24/01/2016.
+//  Copyright © 2016 Computertalk Sweden. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^TSMarkdownParserMatchBlock)(NSTextCheckingResult *match, NSMutableAttributedString *attributedString);
+
+@interface TSBaseParser : NSObject
+
+/*
+ Default attributes for `attributedStringFromMarkdown:`.
+ */
+@property (nonatomic, strong, nullable) NSDictionary<NSString *, id> *defaultAttributes;
+
+/* Applies defaultAttributes then markdown */
+- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown;
+
+/* Applies attributes then markdown */
+- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown attributes:(nullable NSDictionary<NSString *, id> *)attributes;
+
+/* Applies markdown */
+- (NSAttributedString *)attributedStringFromAttributedMarkdownString:(NSAttributedString *)attributedString;
+
+/*
+ Adds a custom parsing rule to parser. Use `[TSMarkdownParser new]` for an empty parser.
+ */
+- (void)addParsingRuleWithRegularExpression:(NSRegularExpression *)regularExpression withBlock:(TSMarkdownParserMatchBlock)block;
+
+/* adds escaping parsing support to parser */
+@property (nonatomic, assign) BOOL escapingSupport;
+
+/* adds links autodetection support to parser */
+@property (nonatomic, assign) BOOL linkDetection;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/TSMarkdownParser/TSBaseParser.m
+++ b/TSMarkdownParser/TSBaseParser.m
@@ -1,0 +1,128 @@
+//
+//  TSBaseParser.m
+//  TSMarkdownParser
+//
+//  Created by Antoine Cœur on 24/01/2016.
+//  Copyright © 2016 Computertalk Sweden. All rights reserved.
+//
+
+#import "TSBaseParser.h"
+#import <UIKit/UIKit.h>
+
+@interface TSExpressionBlockPair : NSObject
+
+@property (nonatomic, strong) NSRegularExpression *regularExpression;
+@property (nonatomic, strong) TSMarkdownParserMatchBlock block;
+
++ (TSExpressionBlockPair *)pairWithRegularExpression:(NSRegularExpression *)regularExpression block:(TSMarkdownParserMatchBlock)block;
+
+@end
+
+@implementation TSExpressionBlockPair
+
++ (TSExpressionBlockPair *)pairWithRegularExpression:(NSRegularExpression *)regularExpression block:(TSMarkdownParserMatchBlock)block {
+    TSExpressionBlockPair *pair = [TSExpressionBlockPair new];
+    pair.regularExpression = regularExpression;
+    pair.block = block;
+    return pair;
+}
+
+@end
+
+@interface TSBaseParser ()
+
+@property (nonatomic, strong) NSMutableArray *parsingPairs;
+
+@end
+
+@implementation TSBaseParser
+
+- (instancetype)init {
+    self = [super init];
+    if(self) {
+        _parsingPairs = [NSMutableArray array];
+    }
+    return self;
+}
+
+static NSString *const TSMarkdownEscapingRegex  = @"\\\\.";
+static NSString *const TSMarkdownUnescapingRegex    = @"\\\\[0-9a-z]{4}";
+
+#pragma mark -
+
+- (void)addParsingRuleWithRegularExpression:(NSRegularExpression *)regularExpression withBlock:(TSMarkdownParserMatchBlock)block {
+    @synchronized (self) {
+        [self.parsingPairs addObject:[TSExpressionBlockPair pairWithRegularExpression:regularExpression block:block]];
+    }
+}
+
+- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown {
+    return [self attributedStringFromMarkdown:markdown attributes:self.defaultAttributes];
+}
+
+- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown attributes:(nullable NSDictionary<NSString *, id> *)attributes {
+    NSAttributedString *attributedString;
+    if (! attributes) {
+        attributedString = [[NSAttributedString alloc] initWithString:markdown];
+    } else {
+        attributedString = [[NSAttributedString alloc] initWithString:markdown attributes:attributes];
+    }
+    
+    return [self attributedStringFromAttributedMarkdownString:attributedString];
+}
+
+- (NSAttributedString *)attributedStringFromAttributedMarkdownString:(NSAttributedString *)attributedString {
+    NSMutableAttributedString *mutableAttributedString = [[NSMutableAttributedString alloc] initWithAttributedString:attributedString];
+    
+    @synchronized (self) {
+        if (self.escapingSupport) {
+            NSRegularExpression *escapingParsing = [NSRegularExpression regularExpressionWithPattern:TSMarkdownEscapingRegex options:NSRegularExpressionDotMatchesLineSeparators error:nil];
+            NSArray *matches = [escapingParsing matchesInString:mutableAttributedString.string options:0 range:NSMakeRange(0, mutableAttributedString.length)];
+            [matches enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(NSTextCheckingResult *match, NSUInteger idx, BOOL *stop) {
+                NSRange range = NSMakeRange(match.range.location+1, 1);
+                NSString *matchString = [mutableAttributedString attributedSubstringFromRange:range].string;
+                NSString *escapedString = [NSString stringWithFormat:@"%04x", [matchString characterAtIndex:0]];
+                [mutableAttributedString replaceCharactersInRange:range withString:escapedString];
+            }];
+        }
+        
+        for (TSExpressionBlockPair *expressionBlockPair in self.parsingPairs) {
+            NSTextCheckingResult *match;
+            while((match = [expressionBlockPair.regularExpression firstMatchInString:mutableAttributedString.string options:0 range:NSMakeRange(0, mutableAttributedString.string.length)])){
+                expressionBlockPair.block(match, mutableAttributedString);
+            }
+        }
+        
+        if (self.escapingSupport) {
+            NSRegularExpression *unescapingParsing = [NSRegularExpression regularExpressionWithPattern:TSMarkdownUnescapingRegex options:NSRegularExpressionDotMatchesLineSeparators error:nil];
+            NSArray *matches = [unescapingParsing matchesInString:mutableAttributedString.string options:0 range:NSMakeRange(0, mutableAttributedString.length)];
+            [matches enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(NSTextCheckingResult *match, NSUInteger idx, BOOL *stop) {
+                NSRange range = NSMakeRange(match.range.location+1, 4);
+                NSString *matchString = [mutableAttributedString attributedSubstringFromRange:range].string;
+                char byte_chars[5] = {'\0','\0','\0','\0','\0'};
+                byte_chars[0] = [matchString characterAtIndex:0];
+                byte_chars[1] = [matchString characterAtIndex:1];
+                byte_chars[2] = [matchString characterAtIndex:2];
+                byte_chars[3] = [matchString characterAtIndex:3];
+                unichar whole_char = strtol(byte_chars, NULL, 16);
+                NSString *unescapedString = [NSString stringWithCharacters:&whole_char length:1];
+                [mutableAttributedString replaceCharactersInRange:match.range withString:unescapedString];
+            }];
+        }
+        
+        if (self.linkDetection) {
+            NSDataDetector *dataDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
+            NSArray *results = [dataDetector matchesInString:mutableAttributedString.string options:0 range:NSMakeRange(0, mutableAttributedString.length)];
+            for (NSTextCheckingResult *result in results) {
+                NSString *linkURLString = [mutableAttributedString.string substringWithRange:result.range];
+                [mutableAttributedString addAttribute:NSLinkAttributeName
+                                                value:[NSURL URLWithString:linkURLString]
+                                                range:result.range];
+            }
+            mutableAttributedString = mutableAttributedString;
+        }
+    }
+    return mutableAttributedString;
+}
+
+@end

--- a/TSMarkdownParser/TSMarkdownParser.h
+++ b/TSMarkdownParser/TSMarkdownParser.h
@@ -12,66 +12,101 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^TSMarkdownParserFormattingBlock)(NSMutableAttributedString *attributedString, NSRange range);
+typedef void (^TSMarkdownParserLevelFormattingBlock)(NSMutableAttributedString *attributedString, NSRange range, NSUInteger level);
 
 @interface TSMarkdownParser : TSBaseParser
 
 /*
  Properties used by standardParser.
  */
-@property (nonatomic, strong) UIFont *h1Font;
-@property (nonatomic, strong) UIFont *h2Font;
-@property (nonatomic, strong) UIFont *h3Font;
-@property (nonatomic, strong) UIFont *h4Font;
-@property (nonatomic, strong) UIFont *h5Font;
-@property (nonatomic, strong) UIFont *h6Font;
-@property (nonatomic, strong) UIColor *linkColor;
-@property (nonatomic, strong) NSNumber *linkUnderlineStyle;// NSUnderlineStyle
-@property (nonatomic, strong) UIFont *monospaceFont;
-@property (nonatomic, strong) UIColor *monospaceTextColor;
-@property (nonatomic, strong) UIFont *strongFont;
-@property (nonatomic, strong) UIFont *emphasisFont;
+@property (nonatomic, strong) NSArray<NSDictionary<NSString *, id> *> *headerAttributes;
+@property (nonatomic, strong) NSArray<NSDictionary<NSString *, id> *> *listAttributes;
+@property (nonatomic, strong) NSArray<NSDictionary<NSString *, id> *> *quoteAttributes;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *imageAttributes;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *linkAttributes;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *monospaceAttributes;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *strongAttributes;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *emphasisAttributes;
 
 /*
  Provides the following default parsing rules from below examples:
- * Header using h1Font, h2Font, h3Font, h4Font, h5Font, h6Font
- * List
- * Image
- * Link using linkColor, linkUnderlineStyle
- * Monospaced using monospaceFont, monospaceTextColor
- * Strong using strongFont
- * Emphasis using emphasisFont
- * default escapingSupport YES
- * default linkDetection YES
- You can use `[TSMarkdownParser new]` for an empty markdown parser.
+ * Escaping parsing
+ * Code escaping parsing using monospaceAttributes
+ * Header using headerAttributes
+ * List using listAttributes
+ * Quote using quoteAttributes
+ * Image using imageAttributes
+ * Link using linkAttributes
+ * LinkDetection using linkAttributes
+ * Strong using strongAttributes
+ * Emphasis using emphasisAttributes
  */
 + (instancetype)standardParser;
 
-/* examples block parsing: headers and lists */
+/*
+ It is recommended to use `[TSMarkdownParser new]` for an empty markdown parser.
+ If you reuse some examples below, it is adviced to use them in the given order.
+ */
+
+/* 1. examples escaping parsing */
+
+// accepts "\."; ALWAYS use together with `addUnescapingParsing`
+- (void)addEscapingParsing;
+// accepts "`code`", "``code``", ...; ALWAYS use together with `addCodeUnescapingParsingWithFormattingBlock:`
+- (void)addCodeEscapingParsing;
+
+/* 2. examples regular block parsing: headers, lists and quotes */
 
 // accepts "# text", "## text", ...
-- (void)addHeaderParsingWithLevel:(int)header formattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
-// accepts "#text", "##text", ... (conflicts with inline parsing)
-- (void)addShortHeaderParsingWithLevel:(int)header formattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
-// accepts "* text", "+ text", "- text"
-- (void)addListParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
-// accepts "*text", "+text", "-text" (conflicts with inline parsing)
-- (void)addShortListParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
+- (void)addHeaderParsingWithMaxLevel:(unsigned int)maxLevel leadFormattingBlock:(TSMarkdownParserLevelFormattingBlock)leadFormattingBlock textFormattingBlock:(nullable TSMarkdownParserLevelFormattingBlock)formattingBlock;
+// accepts "* text", "+ text", "- text", "** text", "++ text", "-- text", ...
+- (void)addListParsingWithMaxLevel:(unsigned int)maxLevel leadFormattingBlock:(TSMarkdownParserLevelFormattingBlock)leadFormattingBlock textFormattingBlock:(nullable TSMarkdownParserLevelFormattingBlock)formattingBlock;
+// accepts "> text", ">> text", ...
+- (void)addQuoteParsingWithMaxLevel:(unsigned int)maxLevel leadFormattingBlock:(TSMarkdownParserLevelFormattingBlock)leadFormattingBlock textFormattingBlock:(nullable TSMarkdownParserLevelFormattingBlock)formattingBlock;
 
-/* examples bracket parsing: images and links */
+/* 3. examples short block parsing: headers and lists */
+/* they are discouraged and not used by standardParser */
+
+// accepts "#text", "##text", ...
+// (conflicts with inline parsing)
+- (void)addShortHeaderParsingWithMaxLevel:(unsigned int)maxLevel leadFormattingBlock:(TSMarkdownParserLevelFormattingBlock)leadFormattingBlock textFormattingBlock:(nullable TSMarkdownParserLevelFormattingBlock)formattingBlock;
+// accepts "*text", "+text", "-text", "** text", "++ text", "-- text", ...
+// (conflicts with inline parsing)
+- (void)addShortListParsingWithMaxLevel:(unsigned int)maxLevel leadFormattingBlock:(TSMarkdownParserLevelFormattingBlock)leadFormattingBlock textFormattingBlock:(nullable TSMarkdownParserLevelFormattingBlock)formattingBlock;
+// accepts ">text", ">>text", ...
+// (conflicts with inline parsing)
+- (void)addShortQuoteParsingWithMaxLevel:(unsigned int)maxLevel leadFormattingBlock:(TSMarkdownParserLevelFormattingBlock)leadFormattingBlock textFormattingBlock:(nullable TSMarkdownParserLevelFormattingBlock)formattingBlock;
+
+/* 4. examples inline bracket parsing: images and links */
+/* text accepts newlines and non-bracket parsing */
 
 // accepts "![text](image)"
 - (void)addImageParsingWithImageFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock alternativeTextFormattingBlock:(TSMarkdownParserFormattingBlock)alternativeFormattingBlock;
 // accepts "[text](link)"
 - (void)addLinkParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 
-/* examples inline parsing: monospaced, strong and emphasis */
+/* 5. example autodetection parsing: links */
 
-// accepts "`text`"
+// adds links autodetection support to parser
+- (void)addLinkDetectionWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
+
+/* 6. examples inline parsing: monospaced, strong, emphasis and link detection */
+/* text accepts newlines */
+
+// accepts "`text`", "``text``", ... (conflicts with `addCodeEscapingParsing`)
 - (void)addMonospacedParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 // accepts "**text**", "__text__"
 - (void)addStrongParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 // accepts "*text*", "_text_"
 - (void)addEmphasisParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
+
+/* 7. examples unescaping parsing */
+/* to use together with `addEscapingParsing` or `addCodeEscapingParsing` */
+
+// accepts "\hexa"; to use with `addEscapingParsing`
+- (void)addUnescapingParsing;
+// accepts "`hexa`", "``hexa``", ...; to use with `addCodeEscapingParsing`
+- (void)addCodeUnescapingParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 
 @end
 

--- a/TSMarkdownParser/TSMarkdownParser.h
+++ b/TSMarkdownParser/TSMarkdownParser.h
@@ -7,56 +7,72 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "TSBaseParser.h"
 
-typedef void (^TSMarkdownParserMatchBlock)(NSTextCheckingResult *match, NSMutableAttributedString *attributedString);
+NS_ASSUME_NONNULL_BEGIN
+
 typedef void (^TSMarkdownParserFormattingBlock)(NSMutableAttributedString *attributedString, NSRange range);
 
-@interface TSMarkdownParser : NSObject
+@interface TSMarkdownParser : TSBaseParser
 
-@property (nonatomic, strong) UIFont *paragraphFont;
-@property (nonatomic, strong) UIFont *strongFont;
-@property (nonatomic, strong) UIFont *emphasisFont;
+/*
+ Properties used by standardParser.
+ */
 @property (nonatomic, strong) UIFont *h1Font;
 @property (nonatomic, strong) UIFont *h2Font;
 @property (nonatomic, strong) UIFont *h3Font;
 @property (nonatomic, strong) UIFont *h4Font;
 @property (nonatomic, strong) UIFont *h5Font;
 @property (nonatomic, strong) UIFont *h6Font;
+@property (nonatomic, strong) UIColor *linkColor;
+@property (nonatomic, strong) NSNumber *linkUnderlineStyle;// NSUnderlineStyle
 @property (nonatomic, strong) UIFont *monospaceFont;
 @property (nonatomic, strong) UIColor *monospaceTextColor;
-@property (nonatomic, strong) UIColor *linkColor;
-@property (nonatomic, copy) NSNumber *linkUnderlineStyle;
+@property (nonatomic, strong) UIFont *strongFont;
+@property (nonatomic, strong) UIFont *emphasisFont;
 
+/*
+ Provides the following default parsing rules from below examples:
+ * Header using h1Font, h2Font, h3Font, h4Font, h5Font, h6Font
+ * List
+ * Image
+ * Link using linkColor, linkUnderlineStyle
+ * Monospaced using monospaceFont, monospaceTextColor
+ * Strong using strongFont
+ * Emphasis using emphasisFont
+ * default escapingSupport YES
+ * default linkDetection YES
+ You can use `[TSMarkdownParser new]` for an empty markdown parser.
+ */
 + (instancetype)standardParser;
 
-- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown;
+/* examples block parsing: headers and lists */
 
-- (NSAttributedString *)attributedStringFromMarkdown:(NSString *)markdown attributes:(NSDictionary *)attributes;
-
-- (NSAttributedString *)attributedStringFromAttributedMarkdownString:(NSAttributedString *)attributedString;
-
-- (void)addParsingRuleWithRegularExpression:(NSRegularExpression *)regularExpression withBlock:(TSMarkdownParserMatchBlock)block;
-
-- (void)addParagraphParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
-
-/* block parsing */
-
+// accepts "# text", "## text", ...
 - (void)addHeaderParsingWithLevel:(int)header formattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
-
+// accepts "#text", "##text", ... (conflicts with inline parsing)
+- (void)addShortHeaderParsingWithLevel:(int)header formattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
+// accepts "* text", "+ text", "- text"
 - (void)addListParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
+// accepts "*text", "+text", "-text" (conflicts with inline parsing)
+- (void)addShortListParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 
-/* bracket parsing */
+/* examples bracket parsing: images and links */
 
+// accepts "![text](image)"
 - (void)addImageParsingWithImageFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock alternativeTextFormattingBlock:(TSMarkdownParserFormattingBlock)alternativeFormattingBlock;
-
+// accepts "[text](link)"
 - (void)addLinkParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 
-/* inline parsing */
+/* examples inline parsing: monospaced, strong and emphasis */
 
+// accepts "`text`"
 - (void)addMonospacedParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
-
+// accepts "**text**", "__text__"
 - (void)addStrongParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
-
+// accepts "*text*", "_text_"
 - (void)addEmphasisParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/TSMarkdownParserTests/TSMarkdownParserTests.m
+++ b/TSMarkdownParserTests/TSMarkdownParserTests.m
@@ -77,7 +77,7 @@
 
 - (void)testStandardFont {
     UIFont *font = [UIFont systemFontOfSize:12];
-    XCTAssertEqualObjects(self.parser.paragraphFont, font);
+    XCTAssertEqualObjects(self.parser.defaultAttributes[NSFontAttributeName], font);
 }
 
 - (void)testBoldFont {


### PR DESCRIPTION
* added nullability and lightweight typing (Xcode 7 features)
* replacing paragraphFont with defaultAttributes
* standardParser requires a space for List syntax now: https://github.com/laptobbe/TSMarkdownParser/issues/26
* standardParser does not support `||` for strong or `|` for emphasis anymore (it was a bug)
* standardParser does not support `_*` or `*_` for strong anymore (it was a bug)
* standardParser supports character escaping: https://github.com/laptobbe/TSMarkdownParser/issues/20
* standardParser supports link detection: https://github.com/laptobbe/TSMarkdownParser/issues/31