### PR TITLE
Link parsing fixes

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -252,9 +252,8 @@ static NSString *const TSMarkdownEmRegex            = @"(\\*|_)(.+?)(\\1)";
         NSURL *url = [NSURL URLWithString:linkURLString] ?: [NSURL URLWithString:
                                                              [linkURLString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
         
-        NSUInteger linkTextEndLocation = [attributedString.string rangeOfString:@"]" options:kNilOptions range:match.range].location;
-        NSRange linkTextRange = NSMakeRange(match.range.location + 1, linkTextEndLocation - match.range.location - 1);
-        
+        NSRange linkTextRange = NSMakeRange(match.range.location + 1, linkStartInResult - match.range.location - 2);
+      
         // deleting trailing markdown
         [attributedString deleteCharactersInRange:NSMakeRange(linkRange.location - 1, linkRange.length + 2)];
         // formatting link (may alter the length)

--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -138,7 +138,7 @@ static NSString *const TSMarkdownShortQuoteRegex    = @"^(\\>{1,%@})\\s*([^\\>].
 
 // inline bracket regex
 static NSString *const TSMarkdownImageRegex         = @"\\!\\[.*?\\]\\(\\S*\\)";
-static NSString *const TSMarkdownLinkRegex          = @"\\[.*?\\]\\([^\\)]*\\)";
+static NSString *const TSMarkdownLinkRegex          = @"\\[[^\\n]*?\\]\\([^\\)]*\\)";
 
 // inline enclosed regex
 static NSString *const TSMarkdownMonospaceRegex     = @"(`+)(\\s*.*?[^`]\\s*)(\\1)(?!`)";


### PR DESCRIPTION
I'm using this library with lots of editorial content which means use of lots of brackets that are not meant for links and some times brackets within links. This PR solves these render bugs: 

```
This is [not] a link. 

But here's [a link](http://google.com). 
```
Which would match everything between "not" and the last "link" as a link. 

 ```
[a link [with brackets]](http://google.com)
```
Which would not include the last bracket in the link.