### PR TITLE
Add bigger default font sizes for tvOS

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -23,30 +23,46 @@ typedef NSFont UIFont;
     if (!self)
         return nil;
     
-    self.defaultAttributes = @{ NSFontAttributeName: [UIFont systemFontOfSize:12] };
+#if TARGET_OS_TV
+    NSUInteger defaultSize = 29;
+#else
+    NSUInteger defaultSize = 12;
+#endif
     
+    self.defaultAttributes = @{ NSFontAttributeName: [UIFont systemFontOfSize:defaultSize] };
+    
+#if TARGET_OS_TV
+    _headerAttributes = @[ @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:76] },
+                           @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:57] },
+                           @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:48] },
+                           @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:40] },
+                           @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:36] },
+                           @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:32] } ];
+#else
     _headerAttributes = @[ @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:23] },
                            @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:21] },
                            @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:19] },
                            @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:17] },
                            @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:15] },
                            @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:13] } ];
+#endif
+    
     _listAttributes = @[];
-    _quoteAttributes = @[@{NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue-Italic" size:12]}];
+    _quoteAttributes = @[@{NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue-Italic" size:defaultSize]}];
     
     _imageAttributes = @{};
     _linkAttributes = @{ NSForegroundColorAttributeName: [UIColor blueColor],
                          NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle) };
     
     // Courier New and Courier are the only monospace fonts compatible with watchOS 2
-    _monospaceAttributes = @{ NSFontAttributeName: [UIFont fontWithName:@"Courier New" size:12],
+    _monospaceAttributes = @{ NSFontAttributeName: [UIFont fontWithName:@"Courier New" size:defaultSize],
                               NSForegroundColorAttributeName: [UIColor colorWithRed:0.95 green:0.54 blue:0.55 alpha:1] };
-    _strongAttributes = @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:12] };
+    _strongAttributes = @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:defaultSize] };
     
 #if TARGET_OS_IPHONE
-    _emphasisAttributes = @{ NSFontAttributeName: [UIFont italicSystemFontOfSize:12] };
+    _emphasisAttributes = @{ NSFontAttributeName: [UIFont italicSystemFontOfSize:defaultSize] };
 #else
-    _emphasisAttributes = @{ NSFontAttributeName: [[NSFontManager sharedFontManager] convertFont:[UIFont systemFontOfSize:12] toHaveTrait:NSItalicFontMask] };
+    _emphasisAttributes = @{ NSFontAttributeName: [[NSFontManager sharedFontManager] convertFont:[UIFont systemFontOfSize:defaultSize] toHaveTrait:NSItalicFontMask] };
 #endif
     
     return self;


### PR DESCRIPTION
The current default font sizes are pretty much unreadably small on Apple TV. This PR adds some bigger fonts based on the font styles in IB.