### PR TITLE
Add support for headers without whitespace between # and the header

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -189,7 +189,7 @@ static NSString *const TSMarkdownEscapingRegex      = @"\\\\.";
 static NSString *const TSMarkdownUnescapingRegex    = @"\\\\[0-9a-z]{4}";
 
 // lead regex
-static NSString *const TSMarkdownHeaderRegex        = @"^(#{1,%@})\\s+(.+)$";
+static NSString *const TSMarkdownHeaderRegex        = @"^(#{1,%@})\\s*(.+)$";
 static NSString *const TSMarkdownShortHeaderRegex   = @"^(#{1,%@})\\s*([^#].*)$";
 static NSString *const TSMarkdownListRegex          = @"^([\\*\\+\\-]{1,%@})\\s+(.+)$";
 static NSString *const TSMarkdownShortListRegex     = @"^([\\*\\+\\-]{1,%@})\\s*([^\\*\\+\\-].*)$";

--- a/TSMarkdownParserTests/TSMarkdownParserTests.m
+++ b/TSMarkdownParserTests/TSMarkdownParserTests.m
@@ -426,19 +426,18 @@
     }];
 }
 
-// '#header' is not a valid header per markdown syntax and shouldn't be parsed as one
-- (void)testStandardHeaderIsNotParsedWithoutSpaceInBetween {
+- (void)testStandardHeaderIsParsedWithoutSpaceInBetween {
     NSString *header = @"header";
-    NSString *notValidHeader = [NSString stringWithFormat:@"#%@", header];
+    NSString *validHeader = [NSString stringWithFormat:@"#%@", header];
     UIFont *h1Font = self.standardParser.headerAttributes[0][NSFontAttributeName];
     
-    NSAttributedString *attributedString = [self.standardParser attributedStringFromMarkdown:notValidHeader];
+    NSAttributedString *attributedString = [self.standardParser attributedStringFromMarkdown:validHeader];
     NSRange headerRange = [attributedString.string rangeOfString:header];
     [attributedString enumerateAttributesInRange:headerRange options:NSAttributedStringEnumerationReverse usingBlock:^(NSDictionary *attributes, NSRange range, BOOL *stop) {
         UIFont *font = attributes[NSFontAttributeName];
-        XCTAssertNotEqual(font, h1Font);
+        XCTAssertEqual(font, h1Font);
     }];
-    XCTAssertEqualObjects(attributedString.string, notValidHeader);
+    XCTAssertEqualObjects(attributedString.string, header);
 }
 
 - (void)testStandardHeaderIsNotParsedAtNotBeginningOfTheLine {


### PR DESCRIPTION
The original [Markdown specs](https://daringfireball.net/projects/markdown/syntax#header) never mention the required whitespace between a header's `#` and its title.
This PR removes this requirement from the library.