### PR TITLE
# Fix for Issue #62

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -146,15 +146,28 @@ typedef NSFont UIFont;
     /* autodetection */
     
     [defaultParser addLinkDetectionWithLinkFormattingBlock:^(NSMutableAttributedString *attributedString, NSRange range, NSString * _Nullable link) {
-        if (!weakParser.skipLinkAttribute) {
-            NSURL *url = [NSURL URLWithString:link] ?: [NSURL URLWithString:
-                                                        [link stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+        __block BOOL alreadyLinked = NO;
+        [attributedString enumerateAttributesInRange:NSMakeRange(0, attributedString.length)
+                                             options:0
+                                          usingBlock:^(NSDictionary<NSString *,id> * _Nonnull attrs, NSRange existingRange, BOOL * _Nonnull stop) {
+          id value = attrs[NSLinkAttributeName];
+          if (value && NSIntersectionRange(existingRange, range).length != 0) {
+            // this range has a link that overlaps with the autodetect range, so skip
+            alreadyLinked = YES;
+            *stop = YES;
+          }
+        }];
+        if (!alreadyLinked) {
+            if (!weakParser.skipLinkAttribute) {
+                NSURL *url = [NSURL URLWithString:link] ?: [NSURL URLWithString:
+                                                          [link stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
 
-            [attributedString addAttribute:NSLinkAttributeName
-                                     value:url
-                                     range:range];
+                [attributedString addAttribute:NSLinkAttributeName
+                                         value:url
+                                         range:range];
+            }
+            [attributedString addAttributes:weakParser.linkAttributes range:range];
         }
-        [attributedString addAttributes:weakParser.linkAttributes range:range];
     }];
     
     /* inline parsing */

--- a/TSMarkdownParserTests/TSMarkdownParserTests.m
+++ b/TSMarkdownParserTests/TSMarkdownParserTests.m
@@ -290,6 +290,42 @@
     XCTAssertNil(linkAtTheNextCharacter);
 }
 
+- (void)testStandardLinkParsingAutodetectionConflict {
+  NSAttributedString *attributedString = [self.standardParser attributedStringFromMarkdown:@"Hello\n This is a [foo@bar.com](https://www.example.net/) to test Wi-Fi\nat home"];
+  NSURL *link = [attributedString attribute:NSLinkAttributeName atIndex:20 effectiveRange:NULL];
+  XCTAssertEqualObjects(link, [NSURL URLWithString:@"https://www.example.net/"]);
+  XCTAssertTrue([attributedString.string rangeOfString:@"["].location == NSNotFound);
+  XCTAssertTrue([attributedString.string rangeOfString:@"]"].location == NSNotFound);
+  XCTAssertTrue([attributedString.string rangeOfString:@"("].location == NSNotFound);
+  XCTAssertTrue([attributedString.string rangeOfString:@")"].location == NSNotFound);
+  XCTAssertTrue([attributedString.string rangeOfString:@"foo@bar.com"].location != NSNotFound);
+  NSNumber *underline = [attributedString attribute:NSUnderlineStyleAttributeName atIndex:20 effectiveRange:NULL];
+  XCTAssertEqualObjects(underline, @(NSUnderlineStyleSingle));
+  UIColor *linkColor = [attributedString attribute:NSForegroundColorAttributeName atIndex:20 effectiveRange:NULL];
+  XCTAssertEqualObjects(linkColor, [UIColor blueColor]);
+
+  NSURL *linkAtTheNextCharacter = [attributedString attribute:NSLinkAttributeName atIndex:28 effectiveRange:NULL];
+  XCTAssertNil(linkAtTheNextCharacter);
+}
+
+- (void)testStandardLinkParsingAutodetectionConflictOverlap {
+  NSAttributedString *attributedString = [self.standardParser attributedStringFromMarkdown:@"Hello\n This is a [expanded foo@bar.com test](https://www.example.net/) to test Wi-Fi\nat home"];
+  NSURL *link = [attributedString attribute:NSLinkAttributeName atIndex:20 effectiveRange:NULL];
+  XCTAssertEqualObjects(link, [NSURL URLWithString:@"https://www.example.net/"]);
+  XCTAssertTrue([attributedString.string rangeOfString:@"["].location == NSNotFound);
+  XCTAssertTrue([attributedString.string rangeOfString:@"]"].location == NSNotFound);
+  XCTAssertTrue([attributedString.string rangeOfString:@"("].location == NSNotFound);
+  XCTAssertTrue([attributedString.string rangeOfString:@")"].location == NSNotFound);
+  XCTAssertTrue([attributedString.string rangeOfString:@"expanded foo@bar.com test"].location != NSNotFound);
+  NSNumber *underline = [attributedString attribute:NSUnderlineStyleAttributeName atIndex:20 effectiveRange:NULL];
+  XCTAssertEqualObjects(underline, @(NSUnderlineStyleSingle));
+  UIColor *linkColor = [attributedString attribute:NSForegroundColorAttributeName atIndex:20 effectiveRange:NULL];
+  XCTAssertEqualObjects(linkColor, [UIColor blueColor]);
+
+  NSURL *linkAtTheNextCharacter = [attributedString attribute:NSLinkAttributeName atIndex:42 effectiveRange:NULL];
+  XCTAssertNil(linkAtTheNextCharacter);
+}
+
 - (void)testStandardAutoLinkParsing {
     NSAttributedString *attributedString = [self.standardParser attributedStringFromMarkdown:@"Hello\n This is a link https://www.example.net/ to test Wi-Fi\nat home"];
     NSURL *link = [attributedString attribute:NSLinkAttributeName atIndex:24 effectiveRange:NULL];


### PR DESCRIPTION
# Ensured that autodetect linking does not overlap existing links; which happens in case the link text contains text that could be auto detected as links.