### PR TITLE
Fix Emphasis Regex So Links With Underscores are Parsed Properly

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -248,7 +248,7 @@ static NSString *const TSMarkdownLinkRegex          = @"\\[[^\\[]*?\\]\\([^\\)]*
 // inline enclosed regex
 static NSString *const TSMarkdownMonospaceRegex     = @"(`+)(\\s*.*?[^`]\\s*)(\\1)(?!`)";
 static NSString *const TSMarkdownStrongRegex        = @"(\\*\\*|__)(.+?)(\\1)";
-static NSString *const TSMarkdownEmRegex            = @"(\\*|_)(.+?)(\\1)";
+static NSString *const TSMarkdownEmRegex            = @"(\\*|\\b\\*|\\b_)(.+?)(\\1)";
 
 #pragma mark escaping parsing
 

--- a/TSMarkdownParserExample iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TSMarkdownParserExample iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,16 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
     },
     {
       "idiom" : "ipad",
@@ -64,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/TSMarkdownParserExample iOS/Base.lproj/Main.storyboard
+++ b/TSMarkdownParserExample iOS/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15F28b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina5_9" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,21 +18,21 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Markdown Input" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZZU-l0-rSz">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Markdown Input" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZZU-l0-rSz">
                                 <rect key="frame" x="0.0" y="0.0" width="124" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="v1s-M3-Yoi"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ZMY-ui-FQm">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ZMY-ui-FQm">
                                 <rect key="frame" x="0.0" y="21" width="600" height="275"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="275" id="saF-I0-2UD"/>
                                 </constraints>
@@ -49,13 +53,13 @@ http://example.net
                                     <outlet property="delegate" destination="BYZ-38-t0r" id="d3k-vG-hIi"/>
                                 </connections>
                             </textView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Markdown Output" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2dn-8r-mGd">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Markdown Output" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2dn-8r-mGd">
                                 <rect key="frame" x="0.0" y="304" width="138" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="881-OL-fzM">
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="881-OL-fzM">
                                 <rect key="frame" x="138" y="296" width="165" height="29"/>
                                 <segments>
                                     <segment title="UILabel"/>
@@ -65,12 +69,12 @@ http://example.net
                                     <action selector="switchOutput:" destination="BYZ-38-t0r" eventType="valueChanged" id="uMr-r9-Cig"/>
                                 </connections>
                             </segmentedControl>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rc3-ww-Zbe">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Rc3-ww-Zbe">
                                 <rect key="frame" x="0.0" y="325" width="600" height="275"/>
                                 <subviews>
                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xN2-9Z-sK0">
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
@@ -81,14 +85,14 @@ http://example.net
                                     <constraint firstAttribute="bottom" secondItem="xN2-9Z-sK0" secondAttribute="bottom" id="wPw-P5-fAk"/>
                                 </constraints>
                             </scrollView>
-                            <textView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="beI-kg-e92">
+                            <textView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="beI-kg-e92">
                                 <rect key="frame" x="0.0" y="325" width="600" height="275"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="beI-kg-e92" firstAttribute="leading" secondItem="2dn-8r-mGd" secondAttribute="leading" id="17R-dw-pPW"/>
                             <constraint firstItem="2dn-8r-mGd" firstAttribute="top" secondItem="ZMY-ui-FQm" secondAttribute="bottom" constant="8" symbolic="YES" id="1Dx-WG-Ew9"/>

--- a/TSMarkdownParserTests/TSMarkdownParserTests.m
+++ b/TSMarkdownParserTests/TSMarkdownParserTests.m
@@ -100,6 +100,12 @@
     NSAttributedString *attributedString = [self.standardParser attributedStringFromMarkdown:@"Hello\nI drink in *a café* everyday"];
     XCTAssertEqualObjects([attributedString attribute:NSFontAttributeName atIndex:20 effectiveRange:NULL], font);
     XCTAssertEqualObjects(attributedString.string, @"Hello\nI drink in a café everyday");
+
+    NSAttributedString *matchingAsterisksInLinkString = [self.standardParser attributedStringFromMarkdown: @"https://www.google.com/my*favorite*page.html"];
+    XCTAssertEqualObjects(matchingAsterisksInLinkString.string, @"https://www.google.com/myfavoritepage.html");
+
+    NSAttributedString *matchingLeadingAsterisks = [self.standardParser attributedStringFromMarkdown: @"*This should be emphasized.*"];
+    XCTAssertEqualObjects(matchingLeadingAsterisks.string, @"This should be emphasized.");
 }
 
 - (void)testStandardBoldParsingUnderscores {
@@ -114,6 +120,15 @@
     NSAttributedString *attributedString = [self.standardParser attributedStringFromMarkdown:@"Hello\nI drink in _a café_ everyday"];
     XCTAssertEqualObjects([attributedString attribute:NSFontAttributeName atIndex:20 effectiveRange:NULL], font);
     XCTAssertEqualObjects(attributedString.string, @"Hello\nI drink in a café everyday");
+
+    NSAttributedString *nonMatchingUnderscoresInLinkString = [self.standardParser attributedStringFromMarkdown: @"https://www.google.com/my_favorite_page.html"];
+    XCTAssertEqualObjects(nonMatchingUnderscoresInLinkString.string, @"https://www.google.com/my_favorite_page.html");
+
+    NSAttributedString *matchingLeadingUnderscores = [self.standardParser attributedStringFromMarkdown: @"_This should be emphasized._"];
+    XCTAssertEqualObjects(matchingLeadingUnderscores.string, @"This should be emphasized.");
+
+    NSAttributedString *nonMatchingEndOfWordUnderscore = [self.standardParser attributedStringFromMarkdown:@"This should not m_atch_"];
+    XCTAssertEqualObjects(nonMatchingEndOfWordUnderscore.string, @"This should not m_atch_");
 }
 
 - (void)testStandardMonospaceParsing {


### PR DESCRIPTION
### Description of Problem
Links with underscores in them are being parsed with intra-word emphasis, which breaks the link for our users by stripping the underscores and interpreting the text between them as emphasis.

<img width="350" alt="links with underscores are broken" src="https://user-images.githubusercontent.com/8572410/50937400-4cb9c080-1428-11e9-9f92-ce77c4d880a7.png">

---

### Description of Solution
The proposed solution is to restrict intra-word emphasis to asterisks (*) only, and parse underscores (_) as emphasis only if they're at the beginning of a word.

Markdown Input | Expected Output
---------------- | -----------------
`This *is* a match` | This *is* a match
`This _is also_ a match` | This _is also_ a match
`This is an intra*wor*d match` | This is an intra*wor*d match
`This is not an intra_wor_d match` | This is not an intra_wor_d match

Demo of the solution with links:
<img width="350" alt="link parsed as emphasis on iPhone XS simulator" src="https://user-images.githubusercontent.com/8572410/50937175-67d80080-1427-11e9-98b9-6fe8af71f4c1.png">
 